### PR TITLE
Make Sonic Pi receiver script more robust

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ There is also the option to move from the interface to the Sonic PI IDE and add 
 All sounds and timing are handled in Sonic Pi. The graphic user interface is a mix of HTML, CSS and [NexusUI](https://nexus-js.github.io/ui/). The GUI is meant to provide a more accessible way to engage with Machine learning as a tool for performance without needing to know the technical aspects. The GUI provides visual representations of the Model output.
 
 <h2>What you need</h2>
-This project uses the p5js-OSC library and modified code examples by Gene Kogan to handle the OSC messaging between the GUI and Sonic Pi. 
+This project uses the p5js-OSC library and modified code examples by Gene Kogan to handle the OSC messaging between the GUI and Sonic Pi.
 Go to this link for info on how to download and install: https://github.com/genekogan/p5js-osc <br><br>
 
 You will also need to download Sonic Pi. This code is for Sonic Pi v3.2.0
@@ -25,8 +25,8 @@ Go to this link for info on how to download and install: https://sonic-pi.net/
 
 3. Open GUI project in browser.
 
-4. Paste Sonic Pi code into an empty buffer in the Sonic Pi IDE <br>
-**Note:** The Sonic Pi code will not run until you chosen a drum kit and have sent at least one beat from the GUI.
+4. Paste Sonic Pi code into an empty buffer in the Sonic Pi IDE and get it running<br>
+**Note:** You will not hear any sounds until you have chosen a drum kit and have sent at least one beat from the GUI.
 
 5. Set up GUI and Sonic Pi in split screen.
 
@@ -34,12 +34,4 @@ Go to this link for info on how to download and install: https://sonic-pi.net/
 
 7. Enter drum beat in **Original Drum Pattern** Grid then press ***send beat***
 
-8. Start Sonic PI code by pressing ***run***
-
 See this video for how to use all features in this project: https://youtu.be/9GHz_-xZPQs
-
-
-
-
-
-

--- a/Sonic-Pi-receiver.rb
+++ b/Sonic-Pi-receiver.rb
@@ -33,17 +33,16 @@ samples = [
     :elec_twip
   ],
   [
- #insert samples here
+    #insert samples here
   ], [
-  #insert samples here
+    #insert samples here
   ], [
-  #insert samples here
+    #insert samples here
   ]
 ]
 
 step = []
 midiNotes = []
-i = 0
 
 live_loop :receivedNewDrums do
   use_real_time
@@ -76,18 +75,15 @@ end
 
 a = 1.4
 
-live_loop :playDrumPatterns do
-  midiNotes = get[:notes]
-  step = get[:steps]
-  genNote = get[:genNotes]
-  genStep = get[:genSteps]
+live_loop :playDrumPatterns, sync: :selectKit do
+  midiNotes = get[:notes] || []
+  step = get[:steps] || []
+  genNote = get[:genNotes] || []
+  genStep = get[:genSteps] || []
   playGen = get[:playGenOrNot]
-  if i == nil
-    i = 0
-  else
-    i = get[:kit]
-    i = i[0].to_i
-  end
+
+  i = get[:kit][0].to_i
+
   dr = { samples[i][0] => 36,
          samples[i][1] =>  46,
          samples[i][2] =>  38,
@@ -98,32 +94,32 @@ live_loop :playDrumPatterns do
          samples[i][7] =>  49,
          samples[i][8] => 45
          }
-  
-  if playGen[0] == 1 || playGen[0] == 2
-    16.times do |i|
-      for x in 0..midiNotes.length do
+
+  if playGen
+    if playGen[0] == 1 || playGen[0] == 2
+      16.times do |i|
+        for x in 0..midiNotes.length do
           if step[x] == i
-            sample dr.index(midiNotes[x]), amp: a
+            sample dr.select{|k,v| v == midiNotes[x]}.keys.first, amp: a
           end
         end
         osc "/druminfo", i, 0
         sleep 0.25
       end
     end
-    
+
     if playGen[0] == 0 || playGen[0] == 2
       16.times do |i|
         for x in 0..genNote.length do
-            if genStep[x] == i
-              sample dr.index(genNote[x]), amp: a
-              puts dr.index(genNote[x])
-            end
+          if genStep[x] == i
+            sample dr.select{|k,v| v == genNote[x]}.keys.first, amp: a
           end
-          osc "/druminfo", i, 1
-          sleep 0.25
         end
+        osc "/druminfo", i, 1
+        sleep 0.25
       end
     end
-    
-    
-    
+  else
+    sleep 0.25
+  end
+end


### PR DESCRIPTION
Previously, the script would generate several errors.
One seemed to be due to calling an invalid method on a hash.
Others seemed to be due to certain time state variables that sometimes
may have not been initialised properly.
These have now been fixed - the Sonic Pi script should (hopefully) no
longer generate errors when getting started. However, it also will not
play any sounds until at least both of the following are done
(in any order):
- the user has sent the appropriate beats with the 'Send Beat' and/or
'Send Generated Beat' buttons, depending on which type(s) of beat they
wish to play
- the user has selected a drum kit with the kit dropdown selector.